### PR TITLE
By default, the vacuum entity should be disabled for new entries. 

### DIFF
--- a/custom_components/moebot/vacuum.py
+++ b/custom_components/moebot/vacuum.py
@@ -63,6 +63,8 @@ class MoeBotVacuumEntity(BaseMoeBotEntity, StateVacuumEntity):
         self._attr_supported_features |= VacuumEntityFeature.STATE
         self._attr_supported_features |= VacuumEntityFeature.START
 
+        self._attr_entity_registry_enabled_default = False
+
     @property
     def state(self) -> str | None:
         mb_state = self._moebot.state


### PR DESCRIPTION
The vacuum will likely be removed in the very near future.